### PR TITLE
Implement table view animations

### DIFF
--- a/Hound/View Controllers/Settings/Pages/Family Page/SettingsFamilyVC.swift
+++ b/Hound/View Controllers/Settings/Pages/Family Page/SettingsFamilyVC.swift
@@ -288,9 +288,12 @@ final class SettingsFamilyVC: HoundScrollViewController, UITableViewDelegate, UI
                             return
                         }
                         
-                        // TODO ANIMATIONS add reload animations
                         self.repeatableSetup()
-                        self.familyMembersTableView.reloadData()
+                        self.familyMembersTableView.deleteRows(at: [indexPath], with: .automatic)
+                        UIView.animate(withDuration: VisualConstant.AnimationConstant.moveMultipleElements) {
+                            self.view.setNeedsLayout()
+                            self.view.layoutIfNeeded()
+                        }
                     }
                 }
             }

--- a/Hound/View Controllers/Settings/Pages/Subscription Page/SettingsSubscriptionVC.swift
+++ b/Hound/View Controllers/Settings/Pages/Subscription Page/SettingsSubscriptionVC.swift
@@ -220,8 +220,9 @@ final class SettingsSubscriptionVC: HoundScrollViewController, UITableViewDelega
                 
                 // When we reload the tableView, cells are reusable.
                 self.lastSelectedCell = nil
-                // TODO ANIMATIONS add reload animations
-                self.tableView.reloadData()
+                UIView.transition(with: self.tableView, duration: VisualConstant.AnimationConstant.moveMultipleElements, options: .transitionCrossDissolve, animations: {
+                    self.tableView.reloadData()
+                })
             }
         }
     }
@@ -255,8 +256,9 @@ final class SettingsSubscriptionVC: HoundScrollViewController, UITableViewDelega
                 
                 PresentationManager.enqueueBanner(forTitle: VisualConstant.BannerTextConstant.successPurchasedSubscriptionTitle, forSubtitle: VisualConstant.BannerTextConstant.successPurchasedSubscriptionSubtitle, forStyle: .success)
                 
-                // TODO ANIMATIONS add reload animations
-                self.tableView.reloadData()
+                UIView.transition(with: self.tableView, duration: VisualConstant.AnimationConstant.moveMultipleElements, options: .transitionCrossDissolve, animations: {
+                    self.tableView.reloadData()
+                })
             }
         }
         


### PR DESCRIPTION
## Summary
- remove reminders with row deletion animation
- animate log deletions with row/section animations
- cross dissolve subscription table updates
- animate removal of family members
- restore setDogManager logic without breaking delete animations

## Testing
- `swift --version`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687861d76664832d85f95533cbc155ae